### PR TITLE
Fix errors due to wrong letter cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ This plugin is implemented base on top of [Embla Carousel](https://github.com/da
 |     height     |             25rem              | Height of carousel component. Default is 25rem.                                                                                                          |
 |      loop      |           true/false           | Images loop or not. Default is false.                                                                                                                    |
 |   direction    |            ltr/rtl             | Left to right or right to left. Default is ltr.                                                                                                          |
-|   SlidesSize   |       eg. 100%/50%/33.3%       | Size of each image. Default is 100%.                                                                                                                     |
-| SlidesToScroll |        'auto' or number        | The number of images skipped per page turn. auto indicates that the value is automatically set. You can also set the number yourself. Default is 'auto'. |
+|   slidessize   |       eg. 100%/50%/33.3%       | Size of each image. Default is 100%.                                                                                                                     |
+| slidesToScroll |        'auto' or number        | The number of images skipped per page turn. auto indicates that the value is automatically set. You can also set the number yourself. Default is 'auto'. |
 |    dragfree    |           true/false           | Represents whether images are automatically adsorbed when you drag and drop them. Default is false.                                                      |
 |     align      |        start/center/end        | The position where the image is adsorbed in the viewport. start indicates the adsorption on the left side. Default is center                             |
 |      axis      |              x/y               | Represents the direction of the roll. Default is x.                                                                                                      |
 |    autoplay    |           true/false           | When set to true, carousel will automatically **skip** to the next image every 3s. Default is false.                                                     |
 |   autoscroll   |           true/false           | When set to true, carousel will automatically **scroll** to the next image every 3s. Default is false.                                                   |
 |      fade      |           true/false           | When switching images, the switching style is changed from scroll to fade.                                                                               |
-|  Arrowbutton   |           true/false           | You can hide arrow buttons by setting `Arrowbutton: false`. Default is true.                                                                             |
+|  arrowbutton   |           true/false           | You can hide arrow buttons by setting `Arrowbutton: false`. Default is true.                                                                             |
 
 ## Example
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,8 +87,8 @@ export function parseSource(plugin: CarouselPlugin, source: string): CarouselOpt
         case "thumb":
           carouseloptions.thumb = value.trim() === "true";
           break;
-        case "arrawbutton":
-          carouseloptions.arrawbutton = value.trim() === "true";
+        case "arrowbutton":
+          carouseloptions.arrowbutton = value.trim() === "true";
           break;
       }
     }


### PR DESCRIPTION
- A typo causes `arrowbutton` fail to be hidden/revealed
- Some typo in README.md offers wrong setting APIs